### PR TITLE
Add MAX6675 Library

### DIFF
--- a/Examples/MAX6675/ReadTemperature/.gitignore
+++ b/Examples/MAX6675/ReadTemperature/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Examples/MAX6675/ReadTemperature/Package.mmp
+++ b/Examples/MAX6675/ReadTemperature/Package.mmp
@@ -1,0 +1,17 @@
+# This is a MadMachine project file in TOML format
+# This file holds those parameters that could not be managed by SwiftPM
+# Edit this file would change the behavior of the building/downloading procedure
+# Those project files in the dependent libraries would be IGNORED
+
+# Specify the board name below
+# There are "SwiftIOBoard" and "SwiftIOFeather" now
+board = "SwiftIOBoard"
+
+# Specifiy the target triple below
+# There are "thumbv7em-unknown-none-eabi" and "thumbv7em-unknown-none-eabihf" now
+# If your code use significant floating-point calculation,
+# plz set it to "thumbv7em-unknown-none-eabihf"
+triple = "thumbv7em-unknown-none-eabi"
+
+# Reserved for future use 
+version = 1

--- a/Examples/MAX6675/ReadTemperature/Package.swift
+++ b/Examples/MAX6675/ReadTemperature/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+let package = Package(
+    name: "ReadTemperature",
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(url: "https://github.com/madmachineio/SwiftIO.git", branch: "main"),
+        .package(url: "https://github.com/madmachineio/MadBoards.git",  branch: "main"),
+        .package(url: "https://github.com/madmachineio/MadDrivers.git",  branch: "main"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .executableTarget(
+            name: "ReadTemperature",
+            dependencies: [
+                "SwiftIO",
+                "MadBoards",
+                // use specific library would speed up the compile procedure
+                .product(name: "MAX6675", package: "MadDrivers")
+            ])]
+)

--- a/Examples/MAX6675/ReadTemperature/README.md
+++ b/Examples/MAX6675/ReadTemperature/README.md
@@ -1,0 +1,3 @@
+# ReadTemparure
+
+An example of how to read the temperature with a MAX6675 Sensor.

--- a/Examples/MAX6675/ReadTemperature/Sources/ReadTemperature/main.swift
+++ b/Examples/MAX6675/ReadTemperature/Sources/ReadTemperature/main.swift
@@ -1,0 +1,19 @@
+import MAX6675
+import SwiftIO
+import MadBoard
+
+print("Read tempature with Max6675 sensor.")
+
+let csPin = DigitalOut(Id.D17)
+let spi = SPI(Id.SPI1,csPin: csPin)
+let max6675 = MAX6675(spi: spi)
+
+while true {
+    sleep(ms: 2000)
+    if let temparture = max6675.readCelsius(){
+        print("Temparture is \(temparture)°C")
+    }else {
+        print("Thermocouple input of pins T+ and T- is open.")
+    }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
                 "LIS3DH",
                 "LTR390",
                 "MAG3110",
+                "MAX6675",
                 "MCP4725",
                 "MCP9808",
                 "MLX90393",
@@ -61,6 +62,7 @@ let package = Package(
         .library(name: "LCD1602", targets: ["LCD1602"]),
         .library(name: "LIS3DH", targets: ["LIS3DH"]),
         .library(name: "LTR390", targets: ["LTR390"]),
+        .library(name: "MAX6675", targets: ["MAX6675"]),
         .library(name: "MAG3110", targets: ["MAG3110"]),
         .library(name: "MCP4725", targets: ["MCP4725"]),
         .library(name: "MCP9808", targets: ["MCP9808"]),
@@ -146,6 +148,9 @@ let package = Package(
             name: "MAG3110",
             dependencies: ["SwiftIO",
                            .product(name: "RealModule", package: "swift-numerics")]),
+        .target(
+            name: "MAX6675",
+            dependencies: ["SwiftIO"]),
         .target(
             name: "MCP4725",
             dependencies: ["SwiftIO"]),

--- a/Sources/MAX6675/MAX6675.docc/MAX6675.md
+++ b/Sources/MAX6675/MAX6675.docc/MAX6675.md
@@ -1,0 +1,29 @@
+# ``MAX6675``
+
+The MAX6675 is a sensor module that measure temperatures from 0-1027C with a resolution of 0.25C. The temperature is measured with a K-Thermoelemnt. The data is output in an SPI compatible read-only format with 12 bit resolution.
+
+## Overview
+  
+| Parameter | Description |  
+| --- | --- |  
+| Interface | SPI |
+| Operating temperature | 0°C to 1024 °C |
+| Accuracy (temperature error) | ±2.5°C at 0°C to 700°C 
+| | ±1.5°C at 700°C |
+| | ±4,75°C at 700°C to 1000°C |  
+| Resolution | 0.25°C |  
+| Conversion time | 0.17s to 0.22s |  
+| Operating voltage range | 3.0V to 5V |  
+| Average quiescent current | 0.7 to 1.5 mA |  
+
+## PinOut
+| No. | NAME | Description |
+| --- | --- | --- |
+| 1 | GND | Ground |
+| 2 | T- | Alumel Lead of Type-K Thermocouple. |
+| 3 | T+ | Chromel Lead of Type-K Thermocouple. |
+| 4 | VCC | Supply voltage, 1.4 V to 3.6 V |
+| 5 | SCK | Serial Clock Input |
+| 6 | CS | Chip Select. Set CS low to enable the serial interface. |
+| 7 | SO | Serial Data Output. |
+| 8 | N.C. | No Connection |

--- a/Sources/MAX6675/MAX6675.swift
+++ b/Sources/MAX6675/MAX6675.swift
@@ -1,0 +1,57 @@
+//=== MAX6675.swift --------------------------------------------------------===//
+//
+// Copyright (c) MadMachine Limited
+// Licensed under MIT License
+//
+// Authors: Jan Anstipp
+// Created: 06/16/2022
+//
+// See https://madmachine.io for more information
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftIO
+
+let thermocoupleInputBit: UInt8 = 0b100
+
+public class MAX6675{
+    let spi: SPI
+    
+    
+    public init(spi:SPI){
+        self.spi = spi
+    }
+    
+    /// Reads a temperature from the thermocouple. if the input of the themocouple is open, nul is returned.
+    /// - Returns: Temperature in degree Celsius. if the input of the themocouple is open, nul is returned
+    public func readCelsius() -> Double?{
+        var buffer: [UInt8] = [0,0]
+        spi.read(into: &buffer)
+        
+        if (buffer[1] & thermocoupleInputBit) == thermocoupleInputBit {
+            return nil
+        }
+        
+        return toTemparture(buffer)
+    }
+    
+    /// Checks if the thermocouple input of pins T+ and T- is open.
+    /// - Returns: Is thermocouple input open.
+    public func isThermocoupleInputOpen() -> Bool{
+        var buffer: [UInt8] = [0,0]
+        spi.read(into: &buffer)
+        
+        return (buffer[1] & thermocoupleInputBit) == thermocoupleInputBit
+    }
+    
+}
+
+
+extension MAX6675{
+    func toTemparture(_ data: [UInt8]) -> Double{
+        let uint16 = UInt16(data[0]) << 5 | UInt16(data[1]) >> 3
+        return Double(uint16) * 0.25
+    }
+}
+
+


### PR DESCRIPTION
- library
- docc
- example

This sensor is kept quite simple. Here only one value can be read via SPI therefore very simple library.

What do you think, a pinout for the board like this one would be perfect. It would be nice if you make them yourself. Then you can make them uniform for all sensors.
![Pinout](https://electropeak.com/learn/wp-content/uploads/2020/12/MAX6675-K-Type-Thermocouple-Pinout.jpg)